### PR TITLE
Correct target framework monikers

### DIFF
--- a/tests/Imposter.Abstractions.Tests/Imposter.Abstractions.Tests.csproj
+++ b/tests/Imposter.Abstractions.Tests/Imposter.Abstractions.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>.net8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Imposter.CodeGenerator.Tests</RootNamespace>
     <LangVersion>12</LangVersion>
   </PropertyGroup>

--- a/tests/Imposter.CodeGenerator.Tests/Imposter.CodeGenerator.Tests.csproj
+++ b/tests/Imposter.CodeGenerator.Tests/Imposter.CodeGenerator.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>.net8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Imposter.CodeGenerator.Tests</RootNamespace>
     <LangVersion>12</LangVersion>
   </PropertyGroup>


### PR DESCRIPTION
This project corrects target framework monikers in a couple of project files. They are specified incorrectly as `.net8.0` instead of `net8.0`.