### PR TITLE
Fix typo in NuGet package description

### DIFF
--- a/src/Imposter.CodeGenerator/Imposter.CodeGenerator.csproj
+++ b/src/Imposter.CodeGenerator/Imposter.CodeGenerator.csproj
@@ -13,7 +13,7 @@
     <!-- Single NuGet package that contains analyzer + runtime -->
     <PackageId>Imposter</PackageId>
     <Version>0.1.0</Version>
-    <Description>Imposter — Mocking library with the perfect blalance of Performance and Intuitive API</Description>
+    <Description>Imposter — Mocking library with the perfect balance of Performance and Intuitive API</Description>
     <PackageTags>source generator;mock;stub;imposter;roslyn;testing</PackageTags>
 
     <Authors>Bitchiko Tchelidze</Authors>


### PR DESCRIPTION
Fixes #43

`<Description>` in `Imposter.CodeGenerator.csproj` read `blalance` — corrected to `balance`. It is the only source of the NuGet description.

nuget.org will not update until the next release, since publishing runs on `release: published`.