### PR TITLE
Harden GitHub Actions token permissions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,6 +11,9 @@ on:
       - develop
   workflow_call:
 
+permissions:
+  contents: read
+
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_NOLOGO: true
@@ -81,4 +84,3 @@ jobs:
 
       - name: Run Imposter.Tests (Roslyn ${{ matrix.roslynVersion }})
         run: dotnet test tests/Imposter.Tests/Imposter.Tests.csproj -p:ROSLYN_VERSION="${{ matrix.roslynVersion }}" -c $BUILD_CONFIGURATION --no-build --logger "console;verbosity=detailed"
-

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,9 @@ on:
   schedule:
     - cron: '25 7 * * 1'
 
+permissions:
+  contents: read
+
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_NOLOGO: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,11 +14,13 @@ on:
         type: string
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,9 @@ on:
     types:
       - published
 
+permissions:
+  contents: read
+
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_NOLOGO: true


### PR DESCRIPTION
## Summary

  - Add read-only top-level permissions to the build, CodeQL, and release workflows
  - Change the docs workflow’s default permission from `contents: write` to `contents: read`
  - Scope `contents: write` to only the jobs that deploy documentation or publish releases
  - Preserve all permissions required by the existing workflows