### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,45 @@
+# Note: .config/dotnet-tools.json (csharpier, husky) has no Dependabot ecosystem;
+# update those manually with `dotnet tool update <tool>`.
+version: 2
+updates:
+  # .NET packages — solution at repo root
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      timezone: "Asia/Tbilisi"
+    ignore:
+      # The Microsoft.CodeAnalysis.CSharp versions in Imposter.Roslyn<V>.props are
+      # deliberate pins that define the Roslyn support matrix (4.0 ... 5.0).
+      # Bumping them would collapse the multi-target packaging — manage manually.
+      - dependency-name: "Microsoft.CodeAnalysis.CSharp"
+      - dependency-name: "Microsoft.CodeAnalysis.Analyzers"
+    groups:
+      nuget:
+        patterns:
+          - "*"
+
+  # Actions used in .github/workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      timezone: "Asia/Tbilisi"
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  # MkDocs toolchain — docs/requirements.txt
+  - package-ecosystem: "pip"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      timezone: "Asia/Tbilisi"
+    groups:
+      docs:
+        patterns:
+          - "*"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs>=1.5
-mkdocs-material>=9.5
-mike>=2.1
-mkdocs-llmstxt>=0.2.0
+mkdocs==1.6.1
+mkdocs-material==9.7.7
+mike==2.2.0
+mkdocs-llmstxt==0.5.0


### PR DESCRIPTION
Adds weekly (Monday) Dependabot checks for NuGet, GitHub Actions, and the MkDocs toolchain, grouped per ecosystem to keep CI load down.

- `Microsoft.CodeAnalysis.CSharp` / `.Analyzers` are excluded — the versions in `Imposter.Roslyn<V>.props` define the Roslyn support matrix and stay manual.
- `docs/requirements.txt` is now pinned exactly (verified with a local `mkdocs build`) so the pip block can actually propose updates.
- `.config/dotnet-tools.json` (CSharpier, Husky) has no Dependabot ecosystem; noted in the config, stays manual.