### PR TITLE
Point Scorecard badge at the live API

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![Build, Test, and Format verification](https://github.com/themidnightgospel/Imposter/actions/workflows/build-and-test.yml/badge.svg?branch=master)](https://github.com/themidnightgospel/Imposter/actions/workflows/build-and-test.yml)
 [![CodeQL](https://github.com/themidnightgospel/Imposter/actions/workflows/codeql.yml/badge.svg)](https://github.com/themidnightgospel/Imposter/actions/workflows/codeql.yml)
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/themidnightgospel/Imposter/badge)](https://scorecard.dev/viewer/?uri=github.com/themidnightgospel/Imposter)
+[![OpenSSF Scorecard](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.scorecard.dev%2Fprojects%2Fgithub.com%2Fthemidnightgospel%2FImposter&query=%24.score&label=openssf%20scorecard)](https://scorecard.dev/viewer/?uri=github.com/themidnightgospel/Imposter)
 [![Nuget](https://img.shields.io/nuget/v/Imposter.svg)](https://www.nuget.org/packages/Imposter)
 
 ## 🧘Balanced Performance and Developer Experience


### PR DESCRIPTION
The canonical Scorecard badge redirects to shields.io's `ossf-scorecard` service, which reads a dataset that does not yet include this repo and renders "invalid repo path" on the homepage. This swaps the badge image to a shields dynamic-json badge reading `$.score` from `api.scorecard.dev`, which serves the published results (renders 7.5 today). Viewer link unchanged.

Can be reverted to the canonical badge URL once `https://api.securityscorecards.dev/projects/github.com/themidnightgospel/Imposter` returns 200 instead of 404.