### PR TITLE
Fix generation for sealed override properties, indexers, and events

### DIFF
--- a/src/Imposter.CodeGenerator/Helpers/ClassSymbolExtensions.cs
+++ b/src/Imposter.CodeGenerator/Helpers/ClassSymbolExtensions.cs
@@ -122,16 +122,16 @@ public static class ClassSymbolExtensions
             return;
         }
 
-        foreach (
-            var property in typeSymbol
-                .GetMembers()
-                .OfType<IPropertySymbol>()
-                .Where(IsOverridableProperty)
-        )
+        foreach (var property in typeSymbol.GetMembers().OfType<IPropertySymbol>())
         {
             if (property.OverriddenProperty is { } overridden)
             {
                 overriddenProperties.Add(overridden);
+            }
+
+            if (!IsOverridableProperty(property))
+            {
+                continue;
             }
 
             if (overriddenProperties.Contains(property))
@@ -168,13 +168,16 @@ public static class ClassSymbolExtensions
             return;
         }
 
-        foreach (
-            var @event in typeSymbol.GetMembers().OfType<IEventSymbol>().Where(IsOverridableEvent)
-        )
+        foreach (var @event in typeSymbol.GetMembers().OfType<IEventSymbol>())
         {
             if (@event.OverriddenEvent is { } overridden)
             {
                 overriddenEvents.Add(overridden);
+            }
+
+            if (!IsOverridableEvent(@event))
+            {
+                continue;
             }
 
             if (overriddenEvents.Contains(@event))

--- a/tests/Imposter.CodeGenerator.Tests/Features/ClassImpersonation/SealedOverrideMemberTests.cs
+++ b/tests/Imposter.CodeGenerator.Tests/Features/ClassImpersonation/SealedOverrideMemberTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Threading.Tasks;
 using Imposter.CodeGenerator.Tests.Helpers;
 using Xunit;
@@ -128,15 +129,12 @@ public class SealedOverrideMemberTests
     private static async Task AssertSetupFails(string setup, string expectedId)
     {
         var context = await TestContextTask.ConfigureAwait(false);
-        foreach (
-            var imposterType in new[]
-            {
-                "SealedOverridesImposter",
-                "InheritedSealedOverridesImposter",
-            }
-        )
+        var diagnosticsByType = new[]
         {
-            var diagnostics = context.CompileSnippet( /*lang=csharp*/
+            "SealedOverridesImposter",
+            "InheritedSealedOverridesImposter",
+        }.Select(imposterType =>
+            context.CompileSnippet( /*lang=csharp*/
                 $$"""
                 using Imposter.Abstractions;
                 namespace Sample
@@ -151,8 +149,11 @@ public class SealedOverrideMemberTests
                     }
                 }
                 """
-            );
+            )
+        );
 
+        foreach (var diagnostics in diagnosticsByType)
+        {
             GeneratorTestHelper.AssertSingleDiagnostic(diagnostics, expectedId, expectedLine: 9);
         }
     }

--- a/tests/Imposter.CodeGenerator.Tests/Features/ClassImpersonation/SealedOverrideMemberTests.cs
+++ b/tests/Imposter.CodeGenerator.Tests/Features/ClassImpersonation/SealedOverrideMemberTests.cs
@@ -1,0 +1,159 @@
+using System.Threading.Tasks;
+using Imposter.CodeGenerator.Tests.Helpers;
+using Xunit;
+
+namespace Imposter.CodeGenerator.Tests.Features.ClassImpersonation;
+
+public class SealedOverrideMemberTests
+{
+    private const string Source = /*lang=csharp*/
+        """
+        using System;
+        using Imposter.Abstractions;
+
+        [assembly: GenerateImposter(typeof(Sample.SealedOverrides))]
+        [assembly: GenerateImposter(typeof(Sample.InheritedSealedOverrides))]
+
+        namespace Sample
+        {
+            public class BaseMembers
+            {
+                public virtual int Value { get; set; }
+                public virtual int this[int index] { get => index; set { } }
+                public virtual event Action Changed { add { } remove { } }
+
+                public virtual int OtherValue { get; set; }
+                public virtual int this[string index] { get => index.Length; set { } }
+                public virtual event Action OtherChanged { add { } remove { } }
+                public virtual int UnchangedValue { get; set; }
+            }
+
+            public class SealedOverrides : BaseMembers
+            {
+                public sealed override int Value { get; set; }
+                public sealed override int this[int index] { get => index; set { } }
+                public sealed override event Action Changed { add { } remove { } }
+
+                public override int OtherValue { get; set; }
+                public override int this[string index] { get => index.Length; set { } }
+                public override event Action OtherChanged { add { } remove { } }
+            }
+
+            public class InheritedSealedOverrides : SealedOverrides { }
+        }
+        """;
+
+    private static readonly Task<GeneratorTestContext> TestContextTask =
+        GeneratorTestHelper.CreateContext(
+            Source,
+            baseSourceFileName: "SealedOverrideMembers.cs",
+            snippetFileName: "Snippet.cs",
+            assemblyName: nameof(SealedOverrideMemberTests)
+        );
+
+    [Fact]
+    public async Task Given_SealedOverrides_When_UsingInstanceAndVirtualSetups_Should_Compile()
+    {
+        await AssertSupportedMembersCompile("SealedOverridesImposter");
+    }
+
+    [Fact]
+    public async Task Given_InheritedSealedOverrides_When_UsingInstanceAndVirtualSetups_Should_Compile()
+    {
+        await AssertSupportedMembersCompile("InheritedSealedOverridesImposter");
+    }
+
+    [Fact]
+    public async Task Given_SealedProperty_When_AccessingSetup_Should_ReportMissingMember()
+    {
+        await AssertSetupFails(
+            "imposter.Value.Getter().Returns(1);",
+            WellKnownCsCompilerErrorCodes.MemberNotFound
+        );
+    }
+
+    [Fact]
+    public async Task Given_SealedIndexer_When_AccessingSetup_Should_ReportInvalidArgument()
+    {
+        // The string indexer remains configurable, but the sealed int overload is absent.
+        await AssertSetupFails("imposter[Arg<int>.Any()].Getter().Returns(1);", "CS1503");
+    }
+
+    [Fact]
+    public async Task Given_SealedEvent_When_AccessingSetup_Should_ReportMissingMember()
+    {
+        await AssertSetupFails(
+            "imposter.Changed.Raised(Count.Once());",
+            WellKnownCsCompilerErrorCodes.MemberNotFound
+        );
+    }
+
+    private static async Task AssertSupportedMembersCompile(string imposterType)
+    {
+        var context = await TestContextTask.ConfigureAwait(false);
+        var diagnostics = context.CompileSnippet( /*lang=csharp*/
+            $$"""
+            using System;
+            using Imposter.Abstractions;
+
+            namespace Sample
+            {
+                public static class Scenario
+                {
+                    public static void Execute()
+                    {
+                        var imposter = new {{imposterType}}();
+                        var instance = imposter.Instance();
+                        instance.Value = instance.Value + 1;
+                        instance[0] = instance[0] + 1;
+                        Action handler = () => { };
+                        instance.Changed += handler;
+                        instance.Changed -= handler;
+
+                        imposter.OtherValue.Getter().Returns(42);
+                        imposter.OtherValue.Setter(Arg<int>.Any()).Called(Count.Never());
+                        imposter[Arg<string>.Any()].Getter().Returns(42);
+                        imposter[Arg<string>.Any()].Setter().Called(Count.Never());
+                        imposter.OtherChanged.Raised(Count.Never());
+                        imposter.UnchangedValue.Getter().Returns(42);
+                    }
+                }
+            }
+            """
+        );
+
+        GeneratorTestHelper.AssertNoDiagnostics(diagnostics);
+    }
+
+    private static async Task AssertSetupFails(string setup, string expectedId)
+    {
+        var context = await TestContextTask.ConfigureAwait(false);
+        foreach (
+            var imposterType in new[]
+            {
+                "SealedOverridesImposter",
+                "InheritedSealedOverridesImposter",
+            }
+        )
+        {
+            var diagnostics = context.CompileSnippet( /*lang=csharp*/
+                $$"""
+                using Imposter.Abstractions;
+                namespace Sample
+                {
+                    public static class Scenario
+                    {
+                        public static void Execute()
+                        {
+                            var imposter = new {{imposterType}}();
+                            {{setup}}
+                        }
+                    }
+                }
+                """
+            );
+
+            GeneratorTestHelper.AssertSingleDiagnostic(diagnostics, expectedId, expectedLine: 9);
+        }
+    }
+}


### PR DESCRIPTION
Generating an imposter for a class with a `sealed override` property, indexer, or event currently produces CS0239 errors: the generated instance tries to override the sealed member. This also affects classes that inherit those sealed overrides.

Record overridden base members before filtering out members that cannot be overridden, matching the existing method-discovery ordering. This prevents sealed members' base definitions from being rediscovered while preserving setup APIs for other virtual members and non-sealed overrides.

Added five regression tests covering direct and inherited sealed overrides, access through the target instance, rejection of setup APIs for sealed members, and compilation of supported virtual-member setups.

Validation:
- Reproduced CS0239 failures for properties, indexers, and events before the fix; all five regression tests pass afterward.
- Full `pwsh ./build-scripts/build-and-test.ps1` passed: 72 abstraction tests, 326 generator tests, 503 behavior tests for each of Roslyn 4.0, 4.4, 4.5, 4.7, 4.11, and 4.14, and 520 behavior tests for Roslyn 5.0.
- CSharpier checks passed for both changed files.
